### PR TITLE
Add edit window

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+/local.properties

--- a/app/src/main/java/org/hse/smartcalendar/activity/DailyTasksListActivity.kt
+++ b/app/src/main/java/org/hse/smartcalendar/activity/DailyTasksListActivity.kt
@@ -49,9 +49,8 @@ fun ListNavigation(
             )
         }
         composable(Screens.EDIT_TASK.route) {
-            TaskEditWindow(onSave = {
-                taskEditViewModel.updateTask()
-            },
+            TaskEditWindow(
+                onSave = {},
                 onDelete = { task ->
                     listViewModel.removeDailyTask(task)
 

--- a/app/src/main/java/org/hse/smartcalendar/activity/DailyTasksListActivity.kt
+++ b/app/src/main/java/org/hse/smartcalendar/activity/DailyTasksListActivity.kt
@@ -4,22 +4,60 @@ import android.os.Bundle
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
 import androidx.activity.enableEdgeToEdge
-import androidx.compose.material3.rememberDrawerState
+import androidx.compose.runtime.Composable
+import androidx.navigation.NavHostController
+import androidx.navigation.compose.NavHost
+import androidx.navigation.compose.composable
 import androidx.navigation.compose.rememberNavController
 import org.hse.smartcalendar.ui.elements.DailyTasksList
+import org.hse.smartcalendar.ui.elements.TaskEditWindow
 import org.hse.smartcalendar.ui.theme.SmartCalendarTheme
+import org.hse.smartcalendar.utility.Screens
 import org.hse.smartcalendar.utility.rememberNavigation
 import org.hse.smartcalendar.view.model.ListViewModel
+import org.hse.smartcalendar.view.model.TaskEditViewModel
 
 class DailyTasksListActivity : ComponentActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         enableEdgeToEdge()
-        val viewModel = ListViewModel(intent.getLongExtra("id", -1))
+        val listViewModel = ListViewModel(intent.getLongExtra("id", -1))
+        val taskEditViewModel = TaskEditViewModel(listViewModel = listViewModel)
         setContent {
+            val navController = rememberNavController()
             SmartCalendarTheme {
-                DailyTasksList(viewModel, {}, rememberNavigation())
+                ListNavigation(listViewModel, taskEditViewModel, navController)
             }
+        }
+    }
+}
+
+@Composable
+fun ListNavigation(
+    listViewModel: ListViewModel,
+    taskEditViewModel: TaskEditViewModel,
+    navController: NavHostController
+) {
+    NavHost(navController = navController, startDestination = Screens.CALENDAR.route) {
+        composable(Screens.CALENDAR.route) {
+            DailyTasksList(
+                listViewModel,
+                taskEditViewModel,
+                { },
+                rememberNavigation(),
+                navController
+            )
+        }
+        composable(Screens.EDIT_TASK.route) {
+            TaskEditWindow(onSave = {
+                taskEditViewModel.updateTask()
+            },
+                onDelete = { task ->
+                    listViewModel.removeDailyTask(task)
+
+                }, onCancel = {},
+                taskEditViewModel = taskEditViewModel, navController = navController
+            )
         }
     }
 }

--- a/app/src/main/java/org/hse/smartcalendar/activity/NavigationActivity.kt
+++ b/app/src/main/java/org/hse/smartcalendar/activity/NavigationActivity.kt
@@ -20,7 +20,6 @@ import kotlinx.coroutines.launch
 import org.hse.smartcalendar.AuthViewModel
 import org.hse.smartcalendar.ui.elements.ChangeLogin
 import org.hse.smartcalendar.ui.elements.ChangePassword
-import org.hse.smartcalendar.ui.elements.DailyTasksList
 import org.hse.smartcalendar.ui.elements.SettingsScreen
 import org.hse.smartcalendar.ui.elements.Statistics
 import org.hse.smartcalendar.ui.theme.SmartCalendarTheme
@@ -86,9 +85,9 @@ fun App(
                     navigation, openDrawer
                 )
             }
-            composable(Screens.CALENDAR.route) {
-                DailyTasksList(listModel, openDrawer = openDrawer, navigation)
-            }
+//            composable(Screens.CALENDAR.route) {
+//                DailyTasksList(listModel, openDrawer = openDrawer)
+//            }
             composable(route = Screens.CHANGE_LOGIN.route) {
                 ChangeLogin(authModel)
             }

--- a/app/src/main/java/org/hse/smartcalendar/activity/NavigationActivity.kt
+++ b/app/src/main/java/org/hse/smartcalendar/activity/NavigationActivity.kt
@@ -20,23 +20,26 @@ import kotlinx.coroutines.launch
 import org.hse.smartcalendar.AuthViewModel
 import org.hse.smartcalendar.ui.elements.ChangeLogin
 import org.hse.smartcalendar.ui.elements.ChangePassword
+import org.hse.smartcalendar.ui.elements.DailyTasksList
 import org.hse.smartcalendar.ui.elements.SettingsScreen
 import org.hse.smartcalendar.ui.elements.Statistics
+import org.hse.smartcalendar.ui.elements.TaskEditWindow
 import org.hse.smartcalendar.ui.theme.SmartCalendarTheme
 import org.hse.smartcalendar.utility.AppDrawer
 import org.hse.smartcalendar.utility.Screens
 import org.hse.smartcalendar.utility.rememberNavigation
 import org.hse.smartcalendar.view.model.ListViewModel
+import org.hse.smartcalendar.view.model.TaskEditViewModel
 
 class NavigationActivity : ComponentActivity() {
-
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         enableEdgeToEdge()
         val listModel = ListViewModel(intent.getLongExtra("id", -1))
+        val editModel = TaskEditViewModel(listModel)
         setContent {
             SmartCalendarTheme {
-                App(AuthViewModel(), listModel)
+                App(AuthViewModel(), listModel, editModel)
             }
         }
     }
@@ -48,6 +51,7 @@ class NavigationActivity : ComponentActivity() {
 fun App(
     authModel: AuthViewModel,
     listModel: ListViewModel,
+    editModel: TaskEditViewModel,
     startDestination: String = Screens.CALENDAR.route
 ) {
     val navigation = rememberNavigation()
@@ -85,9 +89,14 @@ fun App(
                     navigation, openDrawer
                 )
             }
-//            composable(Screens.CALENDAR.route) {
-//                DailyTasksList(listModel, openDrawer = openDrawer)
-//            }
+            composable(Screens.CALENDAR.route) {
+                DailyTasksList(
+                    listModel, openDrawer = openDrawer,
+                    taskEditViewModel = editModel,
+                    navigation = navigation,
+                    navController = navigation.navController
+                )
+            }
             composable(route = Screens.CHANGE_LOGIN.route) {
                 ChangeLogin(authModel)
             }
@@ -96,6 +105,16 @@ fun App(
             }
             composable(route = Screens.STATISTICS.route) {
                 Statistics(openDrawer, navigation)
+            }
+            composable(Screens.EDIT_TASK.route) {
+                TaskEditWindow(
+                    onSave = {},
+                    onDelete = { task ->
+                        listModel.removeDailyTask(task)
+
+                    }, onCancel = {},
+                    taskEditViewModel = editModel, navController = navigation.navController
+                )
             }
         }
     }

--- a/app/src/main/java/org/hse/smartcalendar/data/DailySchedule.kt
+++ b/app/src/main/java/org/hse/smartcalendar/data/DailySchedule.kt
@@ -48,6 +48,16 @@ class DailySchedule (val date : LocalDate = Clock.System.now()
         return false
     }
 
+    fun removeById(id: UUID): Boolean {
+        dailyTasksList.forEach { task ->
+            if (task.getId() == id) {
+                removeDailyTask(task)
+                return true
+            }
+        }
+        return false
+    }
+
     fun getDailyTaskList() : List<DailyTask> {
         return dailyTasksList
     }

--- a/app/src/main/java/org/hse/smartcalendar/data/DailyTask.kt
+++ b/app/src/main/java/org/hse/smartcalendar/data/DailyTask.kt
@@ -49,12 +49,21 @@ class DailyTask (
         return title
     }
 
+    fun setDailyTaskTitle(newTitle: String) {
+        title = newTitle
+    }
+
+
     fun getDailyTaskType(): DailyTaskType {
         return type
     }
 
     fun getDailyTaskDescription() : String {
         return description
+    }
+
+    fun setDailyTaskDescription(newDescription: String) {
+        description = newDescription
     }
 
     fun getDailyTaskStartTime() : LocalTime {

--- a/app/src/main/java/org/hse/smartcalendar/data/DailyTask.kt
+++ b/app/src/main/java/org/hse/smartcalendar/data/DailyTask.kt
@@ -18,8 +18,6 @@ class DailyTask (
     private var start : LocalTime,
     private var end: LocalTime,
     ) {
-
-
     init {
         if (title.isEmpty()) {
             throw EmptyTitleException()
@@ -53,6 +51,13 @@ class DailyTask (
         title = newTitle
     }
 
+    fun setDailyTaskStartTime(newStart: LocalTime) {
+        start = newStart
+    }
+
+    fun setDailyTaskEndTime(newEnd: LocalTime) {
+        end = newEnd
+    }
 
     fun getDailyTaskType(): DailyTaskType {
         return type
@@ -60,6 +65,10 @@ class DailyTask (
 
     fun getDailyTaskDescription() : String {
         return description
+    }
+
+    fun setDailyTaskType(newType: DailyTaskType) {
+        type = newType
     }
 
     fun setDailyTaskDescription(newDescription: String) {

--- a/app/src/main/java/org/hse/smartcalendar/data/DailyTask.kt
+++ b/app/src/main/java/org/hse/smartcalendar/data/DailyTask.kt
@@ -80,6 +80,14 @@ class DailyTask (
                 task.getDailyTaskStartTime() >= this.getDailyTaskEndTime())
     }
 
+    fun updateDailyTask(task: DailyTask) {
+        title = task.title
+        type = task.type
+        description = task.description
+        start = task.start
+        end = task.end
+    }
+
     class TimeConflictException(start: LocalTime, end: LocalTime) : IllegalArgumentException(
         "Illegal start and end time: start = " +
                 start.toString() +

--- a/app/src/main/java/org/hse/smartcalendar/ui/elements/DailyTaskCard.kt
+++ b/app/src/main/java/org/hse/smartcalendar/ui/elements/DailyTaskCard.kt
@@ -29,6 +29,8 @@ import androidx.compose.ui.unit.dp
 import kotlinx.datetime.LocalTime
 import org.hse.smartcalendar.data.DailyTask
 import org.hse.smartcalendar.data.DailyTaskType
+import org.hse.smartcalendar.view.model.ListViewModel
+import org.hse.smartcalendar.view.model.TaskEditViewModel
 
 
 @Composable
@@ -36,13 +38,17 @@ fun DailyTaskCard(
     task: DailyTask,
     modifier: Modifier = Modifier,
     onCompletionChange: () -> Unit = { },
-    onLongPressAction: () -> Unit = { }
+    onLongPressAction: () -> Unit = { },
+    taskEditViewModel: TaskEditViewModel
 ) {
     Column(modifier = Modifier
         .padding(5.dp)
         .pointerInput(Unit) {
             detectTapGestures(
-                onLongPress = { onLongPressAction() }
+                onLongPress = {
+                    taskEditViewModel.setTask(task)
+                    onLongPressAction()
+                }
             )
         }) {
 
@@ -114,6 +120,7 @@ fun DailyTaskCard(
 @Composable
 @Preview(showBackground = true)
 fun DailyTaskCardPreview() {
+    val taskEditViewModel = TaskEditViewModel(listViewModel = ListViewModel(1488))
     val previewCommonTask = DailyTask(
         title = "Common title example",
         type = DailyTaskType.COMMON,
@@ -151,19 +158,23 @@ fun DailyTaskCardPreview() {
     Column {
         DailyTaskCard(
             task = previewCommonTask,
-            onCompletionChange = { previewCommonTask.setCompletion(!previewCommonTask.isComplete()) }
+            onCompletionChange = { previewCommonTask.setCompletion(!previewCommonTask.isComplete()) },
+            taskEditViewModel = taskEditViewModel
         )
         DailyTaskCard(
             task = previewFitnessTask,
-            onCompletionChange = { previewFitnessTask.setCompletion(!previewFitnessTask.isComplete()) }
+            onCompletionChange = { previewFitnessTask.setCompletion(!previewFitnessTask.isComplete()) },
+            taskEditViewModel = taskEditViewModel
         )
         DailyTaskCard(
             task = previewWorkTask,
-            onCompletionChange = { previewWorkTask.setCompletion(!previewWorkTask.isComplete()) }
+            onCompletionChange = { previewWorkTask.setCompletion(!previewWorkTask.isComplete()) },
+            taskEditViewModel = taskEditViewModel
         )
         DailyTaskCard(
             task = previewStudiesTask,
-            onCompletionChange = { previewStudiesTask.setCompletion(!previewStudiesTask.isComplete()) }
+            onCompletionChange = { previewStudiesTask.setCompletion(!previewStudiesTask.isComplete()) },
+            taskEditViewModel = taskEditViewModel
         )
     }
 }

--- a/app/src/main/java/org/hse/smartcalendar/ui/elements/DailyTaskEditWindow.kt
+++ b/app/src/main/java/org/hse/smartcalendar/ui/elements/DailyTaskEditWindow.kt
@@ -69,17 +69,22 @@ fun TaskEditWindow(
         bottomBar = {
             TaskEditBottomBar(
                 onSave = {
-                    taskEditViewModel.changes.updateDailyTask(
-                        DailyTask(
-                            title = titleState.value,
-                            type = taskType.value,
-                            description = descriptionState.value,
-                            start = LocalTime.fromSecondOfDay(startTime.intValue),
-                            end = LocalTime.fromSecondOfDay(endTime.intValue)
+                    taskEditViewModel.changes.setDailyTaskStartTime(
+                        LocalTime.fromMinutesOfDay(
+                            startTime.intValue
                         )
                     )
+                    taskEditViewModel.changes.setDailyTaskEndTime(LocalTime.fromMinutesOfDay(endTime.intValue))
+                    taskEditViewModel.changes.setDailyTaskType(taskType.value)
+                    taskEditViewModel.updateInnerTask(
+                        isEmptyTitle,
+                        isConflictInTimeField,
+                        isNestedTask
+                    )
                     onSave()
-                    navController.navigate(Screens.CALENDAR.route)
+                    if (!isEmptyTitle.value && !isConflictInTimeField.value && !isNestedTask.value) {
+                        navController.navigate(Screens.CALENDAR.route)
+                    }
                 },
                 onCancel = {
                     onCancel()

--- a/app/src/main/java/org/hse/smartcalendar/ui/elements/DailyTaskEditWindow.kt
+++ b/app/src/main/java/org/hse/smartcalendar/ui/elements/DailyTaskEditWindow.kt
@@ -1,0 +1,207 @@
+package org.hse.smartcalendar.ui.elements
+
+import android.annotation.SuppressLint
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.BottomAppBar
+import androidx.compose.material3.Button
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.TextField
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.mutableIntStateOf
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.saveable.rememberSaveable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import androidx.navigation.NavController
+import androidx.wear.compose.material3.Text
+import kotlinx.datetime.LocalTime
+import org.hse.smartcalendar.data.DailyTask
+import org.hse.smartcalendar.data.DailyTaskType
+import org.hse.smartcalendar.utility.Screens
+import org.hse.smartcalendar.view.model.ListViewModel
+import org.hse.smartcalendar.view.model.TaskEditViewModel
+
+@OptIn(ExperimentalMaterial3Api::class)
+@SuppressLint("UnusedMaterial3ScaffoldPaddingParameter")
+@Composable
+fun TaskEditWindow(
+    onSave: () -> Unit,
+    onCancel: () -> Unit,
+    onDelete: (DailyTask) -> Unit,
+    taskEditViewModel: TaskEditViewModel,
+    navController: NavController
+) {
+    val taskState = taskEditViewModel.task
+    val titleState = remember { mutableStateOf(taskState.value.getDailyTaskTitle()) }
+    val taskType = rememberSaveable { mutableStateOf(DailyTaskType.COMMON) }
+    val descriptionState = remember { mutableStateOf(taskState.value.getDailyTaskDescription()) }
+    val startTime = rememberSaveable { mutableIntStateOf(0) }
+    val endTime = rememberSaveable { mutableIntStateOf(0) }
+
+    val isConflictInTimeField = rememberSaveable { mutableStateOf(false) }
+    val isEmptyTitle = rememberSaveable { mutableStateOf(false) }
+    val isNestedTask = rememberSaveable { mutableStateOf(false) }
+    val fstFiledHasFormatError = rememberSaveable { mutableStateOf(false) }
+    val sndFiledHasFormatError = rememberSaveable { mutableStateOf(false) }
+    val expendedTypeSelection = rememberSaveable { mutableStateOf(false) }
+
+    Scaffold(
+        bottomBar = {
+            TaskEditBottomBar(
+                onSave = {
+                    taskEditViewModel.changes.updateDailyTask(
+                        DailyTask(
+                            title = titleState.value,
+                            type = taskType.value,
+                            description = descriptionState.value,
+                            start = LocalTime.fromSecondOfDay(startTime.intValue),
+                            end = LocalTime.fromSecondOfDay(endTime.intValue)
+                        )
+                    )
+                    onSave()
+                    navController.navigate(Screens.CALENDAR.route)
+                },
+                onCancel = {
+                    onCancel()
+                    navController.navigate(Screens.CALENDAR.route)
+                },
+                onDelete = {
+                    onDelete(taskEditViewModel.test)
+                    navController.navigate(Screens.CALENDAR.route)
+                }
+            )
+        },
+        content = {
+            Column(
+                modifier = Modifier
+                    //.navigationBarsPadding()
+                    .padding(12.dp) // Outer padding
+                    .background(color = MaterialTheme.colorScheme.background)
+                    .fillMaxWidth()
+                    .padding(12.dp) // Inner padding
+            )
+            {
+                TextField(
+                    value = titleState.value,
+                    onValueChange = {
+                        titleState.value = it
+                        taskEditViewModel.changes.setDailyTaskTitle(it)
+                    },
+                    label = { Text("Title") },
+                    modifier = Modifier.fillMaxWidth()
+                )
+
+                Spacer(modifier = Modifier.padding(12.dp))
+                ExposedTypeSelectionMenu(
+                    expanded = expendedTypeSelection,
+                    type = taskType
+                )
+                Spacer(modifier = Modifier.padding(5.dp))
+                TextField(
+                    value = descriptionState.value,
+                    onValueChange = {
+                        descriptionState.value = it
+                        taskEditViewModel.changes.setDailyTaskDescription(it)
+                    },
+                    label = { Text("Description") },
+                    modifier = Modifier.fillMaxWidth()
+                )
+
+                Spacer(modifier = Modifier.padding(12.dp))
+
+                TimeSelectorRow(
+                    startTime = startTime,
+                    endTime = endTime,
+                    isConflictInTimeField = isConflictInTimeField,
+                    fstFiledHasFormatError = fstFiledHasFormatError,
+                    sndFiledHasFormatError = sndFiledHasFormatError
+                )
+            }
+        }
+    )
+}
+
+@Preview
+@Composable
+fun TaskEditWindowPreview() {
+    TaskEditWindow(
+        onSave = { },
+        onCancel = { },
+        onDelete = { },
+        taskEditViewModel = TaskEditViewModel(
+            listViewModel = ListViewModel(1488)
+        ),
+        navController = NavController(
+            LocalContext.current
+        )
+    )
+}
+
+@Composable
+fun TaskEditBottomBar(
+    onSave: () -> Unit,
+    onCancel: () -> Unit,
+    onDelete: () -> Unit,
+) {
+    BottomAppBar(
+        containerColor = Color.LightGray,
+        contentColor = Color.White,
+        modifier = Modifier.height(100.dp)
+    ) {
+        Row(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(8.dp)
+                .align(Alignment.Bottom),
+            horizontalArrangement = Arrangement.SpaceEvenly
+        ) {
+            Button(
+                onClick = {
+                    onSave()
+                },
+                modifier = Modifier
+                    .testTag("updateTaskButton")
+                    .weight(1f)
+            ) {
+                androidx.compose.material3.Text("Update")
+            }
+            Spacer(modifier = Modifier.padding(5.dp))
+            Button(
+                onClick = {
+                    onDelete()
+                },
+                modifier = Modifier
+                    .testTag("deleteTaskButton")
+                    .weight(1f)
+            ) {
+                androidx.compose.material3.Text("Delete")
+            }
+            Spacer(modifier = Modifier.padding(5.dp))
+            Button(
+                onClick = {
+                    onCancel()
+                },
+                modifier = Modifier
+                    .testTag("cancelEditButton")
+                    .weight(1f)
+            ) {
+                androidx.compose.material3.Text("Cancel")
+            }
+        }
+    }
+}

--- a/app/src/main/java/org/hse/smartcalendar/ui/elements/DailyTaskEditWindow.kt
+++ b/app/src/main/java/org/hse/smartcalendar/ui/elements/DailyTaskEditWindow.kt
@@ -199,17 +199,6 @@ fun TaskEditBottomBar(
         ) {
             Button(
                 onClick = {
-                    onSave()
-                },
-                modifier = Modifier
-                    .testTag("updateTaskButton")
-                    .weight(1f)
-            ) {
-                androidx.compose.material3.Text("Update")
-            }
-            Spacer(modifier = Modifier.padding(5.dp))
-            Button(
-                onClick = {
                     onDelete()
                 },
                 modifier = Modifier
@@ -217,6 +206,18 @@ fun TaskEditBottomBar(
                     .weight(1f)
             ) {
                 androidx.compose.material3.Text("Delete")
+            }
+
+            Spacer(modifier = Modifier.padding(5.dp))
+            Button(
+                onClick = {
+                    onSave()
+                },
+                modifier = Modifier
+                    .testTag("updateTaskButton")
+                    .weight(1f)
+            ) {
+                androidx.compose.material3.Text("Update")
             }
             Spacer(modifier = Modifier.padding(5.dp))
             Button(

--- a/app/src/main/java/org/hse/smartcalendar/ui/elements/DailyTasksList.kt
+++ b/app/src/main/java/org/hse/smartcalendar/ui/elements/DailyTasksList.kt
@@ -55,9 +55,7 @@ import org.hse.smartcalendar.view.model.TaskEditViewModel
 @Composable
 fun DailyTasksList(
     viewModel: ListViewModel,
-    taskEditViewModel: TaskEditViewModel = TaskEditViewModel(
-        listViewModel = viewModel
-    ),
+    taskEditViewModel: TaskEditViewModel,
     openDrawer: () -> Unit,
     navigation: Navigation,
     navController: NavController

--- a/app/src/main/java/org/hse/smartcalendar/ui/elements/SettingsScreen.kt
+++ b/app/src/main/java/org/hse/smartcalendar/ui/elements/SettingsScreen.kt
@@ -24,19 +24,26 @@ import androidx.compose.ui.semantics.Role
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
-import org.hse.smartcalendar.activity.App
 import org.hse.smartcalendar.AuthViewModel
+import org.hse.smartcalendar.activity.App
 import org.hse.smartcalendar.ui.theme.SmartCalendarTheme
 import org.hse.smartcalendar.utility.Navigation
 import org.hse.smartcalendar.utility.Screens
 import org.hse.smartcalendar.view.model.ListViewModel
+import org.hse.smartcalendar.view.model.TaskEditViewModel
 
 //здесь работает навигация
 @Preview
 @Composable
 fun SettingsScreen() {
     SmartCalendarTheme {
-        App(listModel = ListViewModel(-1), authModel = AuthViewModel(), startDestination = Screens.SETTINGS.route)
+        val listModel = ListViewModel(-1)
+        App(
+            listModel = listModel,
+            authModel = AuthViewModel(),
+            editModel = TaskEditViewModel(listModel),
+            startDestination = Screens.SETTINGS.route
+        )
     }
 }
 

--- a/app/src/main/java/org/hse/smartcalendar/utility/ListViewUtility.kt
+++ b/app/src/main/java/org/hse/smartcalendar/utility/ListViewUtility.kt
@@ -1,0 +1,26 @@
+package org.hse.smartcalendar.utility
+
+import androidx.compose.runtime.MutableState
+import org.hse.smartcalendar.data.DailyTask
+import org.hse.smartcalendar.view.model.ListViewModel
+
+fun editHandler(
+    oldTask: DailyTask,
+    newTask: DailyTask,
+    viewModel: ListViewModel,
+    isEmptyTitle: MutableState<Boolean>,
+    isConflictInTimeField: MutableState<Boolean>,
+    isNestedTask: MutableState<Boolean>,
+) {
+    isEmptyTitle.value = false
+    isNestedTask.value = false
+    isConflictInTimeField.value = false
+
+    isEmptyTitle.value = newTask.getDailyTaskTitle().isEmpty()
+    isConflictInTimeField.value = newTask.getDailyTaskStartTime() > newTask.getDailyTaskEndTime()
+    isNestedTask.value = !viewModel.isUpdatable(oldTask, newTask)
+
+    if (!isEmptyTitle.value && !isConflictInTimeField.value && !isNestedTask.value) {
+        oldTask.updateDailyTask(newTask)
+    }
+}

--- a/app/src/main/java/org/hse/smartcalendar/utility/Navigation.kt
+++ b/app/src/main/java/org/hse/smartcalendar/utility/Navigation.kt
@@ -14,6 +14,7 @@ enum class Screens(val route: String) {
     SETTINGS( "settings"),
     STATISTICS( "statistics"),
     ACHIEVEMENTS("achievements"),
+    EDIT_TASK("editTask"),
     MY_CALENDARS("myCalendars"),
     RATING("rating"),
     AI_ASSISTANT("aiAssistant")

--- a/app/src/main/java/org/hse/smartcalendar/view/model/ListViewModel.kt
+++ b/app/src/main/java/org/hse/smartcalendar/view/model/ListViewModel.kt
@@ -91,6 +91,17 @@ class ListViewModel(id: Long) : ViewModel() {
         return dailyScheduleDate.value
     }
 
+    fun isUpdatable(oldTask: DailyTask, newTask: DailyTask): Boolean {
+        dailyTaskSchedule.getDailyTaskList().forEach { task ->
+            if (task != oldTask) {
+                if (oldTask.isNestedTasks(newTask)) {
+                    throw NestedTask(task)
+                }
+            }
+        }
+        return true
+    }
+
     private fun <T> SnapshotStateList(dailyTaskList: List<T>): SnapshotStateList<T> {
         val result: SnapshotStateList<T> = SnapshotStateList()
         dailyTaskList.forEach { task ->
@@ -98,4 +109,8 @@ class ListViewModel(id: Long) : ViewModel() {
         }
         return result
     }
+
+
+    class NestedTask(val nestedTask: DailyTask) :
+        Exception("Collision in list in case of updating")
 }

--- a/app/src/main/java/org/hse/smartcalendar/view/model/ListViewModel.kt
+++ b/app/src/main/java/org/hse/smartcalendar/view/model/ListViewModel.kt
@@ -92,10 +92,13 @@ class ListViewModel(id: Long) : ViewModel() {
     }
 
     fun isUpdatable(oldTask: DailyTask, newTask: DailyTask): Boolean {
+        if (!dailyTaskSchedule.getDailyTaskList().contains(oldTask)) {
+            return false
+        }
         dailyTaskSchedule.getDailyTaskList().forEach { task ->
             if (task != oldTask) {
-                if (oldTask.isNestedTasks(newTask)) {
-                    throw NestedTask(task)
+                if (task.isNestedTasks(newTask)) {
+                    return false
                 }
             }
         }
@@ -109,7 +112,6 @@ class ListViewModel(id: Long) : ViewModel() {
         }
         return result
     }
-
 
     class NestedTask(val nestedTask: DailyTask) :
         Exception("Collision in list in case of updating")

--- a/app/src/main/java/org/hse/smartcalendar/view/model/TaskEditViewModel.kt
+++ b/app/src/main/java/org/hse/smartcalendar/view/model/TaskEditViewModel.kt
@@ -12,16 +12,23 @@ class TaskEditViewModel(
         description = "Preview description",
         start = LocalTime(0, 0),
         end = LocalTime(23, 59)
-    )
+    ),
+    val listViewModel: ListViewModel
 ) : ViewModel() {
-    private val _task = mutableStateOf(task)
+    private var _task = mutableStateOf(task)
+    val changes = task
+    var test = task
     val task: State<DailyTask> = _task
 
-    fun updateTitle(newTitle: String) {
-        _task.value.setDailyTaskTitle(newTitle)
+    fun setTask(newTask: DailyTask) {
+        _task = mutableStateOf(newTask)
+        test = newTask
+        changes.updateDailyTask(newTask)
     }
 
-    fun updateDescription(newDescription: String) {
-        _task.value.setDailyTaskDescription(newDescription)
+    fun updateTask() {
+        if (listViewModel.isUpdatable(_task.value, changes)) {
+            _task.value.updateDailyTask(changes)
+        }
     }
 }

--- a/app/src/main/java/org/hse/smartcalendar/view/model/TaskEditViewModel.kt
+++ b/app/src/main/java/org/hse/smartcalendar/view/model/TaskEditViewModel.kt
@@ -1,34 +1,41 @@
 package org.hse.smartcalendar.view.model
 
-import androidx.compose.runtime.State
-import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.MutableState
 import androidx.lifecycle.ViewModel
 import kotlinx.datetime.LocalTime
 import org.hse.smartcalendar.data.DailyTask
+import org.hse.smartcalendar.utility.editHandler
 
 class TaskEditViewModel(
-    task: DailyTask = DailyTask(
+    val listViewModel: ListViewModel
+) : ViewModel() {
+    private var task: DailyTask = DailyTask(
         title = "Preview title",
         description = "Preview description",
         start = LocalTime(0, 0),
         end = LocalTime(23, 59)
-    ),
-    val listViewModel: ListViewModel
-) : ViewModel() {
-    private var _task = mutableStateOf(task)
+    )
     val changes = task
     var test = task
     val task: State<DailyTask> = _task
 
     fun setTask(newTask: DailyTask) {
-        _task = mutableStateOf(newTask)
-        test = newTask
+        task = newTask
         changes.updateDailyTask(newTask)
     }
 
-    fun updateTask() {
-        if (listViewModel.isUpdatable(_task.value, changes)) {
-            _task.value.updateDailyTask(changes)
-        }
+    fun updateInnerTask(
+        isEmptyTitle: MutableState<Boolean>,
+        isConflictInTimeField: MutableState<Boolean>,
+        isNestedTask: MutableState<Boolean>,
+    ) {
+        editHandler(
+            oldTask = task,
+            newTask = changes,
+            viewModel = listViewModel,
+            isEmptyTitle = isEmptyTitle,
+            isConflictInTimeField = isConflictInTimeField,
+            isNestedTask = isNestedTask
+        )
     }
 }

--- a/app/src/main/java/org/hse/smartcalendar/view/model/TaskEditViewModel.kt
+++ b/app/src/main/java/org/hse/smartcalendar/view/model/TaskEditViewModel.kt
@@ -1,0 +1,27 @@
+package org.hse.smartcalendar.view.model
+
+import androidx.compose.runtime.State
+import androidx.compose.runtime.mutableStateOf
+import androidx.lifecycle.ViewModel
+import kotlinx.datetime.LocalTime
+import org.hse.smartcalendar.data.DailyTask
+
+class TaskEditViewModel(
+    task: DailyTask = DailyTask(
+        title = "Preview title",
+        description = "Preview description",
+        start = LocalTime(0, 0),
+        end = LocalTime(23, 59)
+    )
+) : ViewModel() {
+    private val _task = mutableStateOf(task)
+    val task: State<DailyTask> = _task
+
+    fun updateTitle(newTitle: String) {
+        _task.value.setDailyTaskTitle(newTitle)
+    }
+
+    fun updateDescription(newDescription: String) {
+        _task.value.setDailyTaskDescription(newDescription)
+    }
+}

--- a/app/src/main/java/org/hse/smartcalendar/view/model/TaskEditViewModel.kt
+++ b/app/src/main/java/org/hse/smartcalendar/view/model/TaskEditViewModel.kt
@@ -16,8 +16,10 @@ class TaskEditViewModel(
         end = LocalTime(23, 59)
     )
     val changes = task
-    var test = task
-    val task: State<DailyTask> = _task
+
+    fun getTask(): DailyTask {
+        return task
+    }
 
     fun setTask(newTask: DailyTask) {
         task = newTask

--- a/local.properties
+++ b/local.properties
@@ -1,8 +1,0 @@
-## This file must *NOT* be checked into Version Control Systems,
-# as it contains information specific to your local configuration.
-#
-# Location of the SDK. This is only used by Gradle.
-# For customization when using a Version Control System, please read the
-# header note.
-#Tue Mar 04 10:35:16 MSK 2025
-sdk.dir=C\:\\Users\\Huawei\\AppData\\Local\\Android\\Sdk


### PR DESCRIPTION
Переписал `DailyTaskActivity`. Теперь тело состоит из `NavHost`'а, который контролирует перемещение между экранами списка и изменения задачь.
Добавил пару методов в ViewModel'ы, которые упрощают изменение задач (теперь не по отдельности меняю каждое поле, а через другого представителя класса 'DailyTask'). 
Написал сам экран изменения задач `DailyTaskEditWindow`.